### PR TITLE
Note in README to use on headless server

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ python gui/run_gui.py
 python gui/run_gui.py --env "memory_maze:MemoryMaze-9x9-HD-v0"
 ```
 
+## Running on a headless server
+
+To run on a headless server, the environment variable `MUJOCO_GL` needs to be set to `egl`.
+It can also be set in the python script as follows:
+```python
+import os
+os.environ['MUJOCO_GL'] = 'egl'
+
+env = gym.make('memory_maze:MemoryMaze-9x9-v0')
+
+print(env.observation_space, env.action_space)
+```
+
 ## Task Description
 
 The task is based on a game known as scavenger hunt or treasure hunt:


### PR DESCRIPTION
Greetings.

Thanks a lot for making this suite of environment publicly available.
I have taken the liberty of jotting down this PR to trick I found in Dreamer-v2 implementation to make it work on a headless server.
Otherwise, it throws up a `gladLoadGL error`.
Hope it can be of some use and sorry in case I missed the official instruction somewhere in the repository.

Best regards.