### PR TITLE
Randomize colors for smaller mazes

### DIFF
--- a/memory_maze/__init__.py
+++ b/memory_maze/__init__.py
@@ -52,6 +52,12 @@ try:
         register(id=f'MemoryMaze-{key}-HiFreq-Vis-v0', entry_point=f(_make_gym_env, dm_task, image_only_obs=True, control_freq=40, good_visibility=True))
         register(id=f'MemoryMaze-{key}-HiFreq-HD-v0', entry_point=f(_make_gym_env, dm_task, image_only_obs=True, control_freq=40, camera_resolution=256))
 
+        # Six colors even for smaller mazes
+        register(id=f'MemoryMaze-{key}-6CL-v0', entry_point=f(_make_gym_env, dm_task, randomize_colors=True, image_only_obs=True))
+        register(id=f'MemoryMaze-{key}-6CL-Top-v0', entry_point=f(_make_gym_env, dm_task, randomize_colors=True, image_only_obs=True, camera_resolution=256, top_camera=True))
+        register(id=f'MemoryMaze-{key}-6CL-ExtraObs-v0', entry_point=f(_make_gym_env, dm_task, randomize_colors=True, global_observables=True))
+        
+
 
 except ImportError:
     print('memory_maze: gym environments not registered.')

--- a/memory_maze/tasks.py
+++ b/memory_maze/tasks.py
@@ -64,6 +64,7 @@ def _memory_maze(
     show_path=False,
     camera_resolution=64,
     seed=None,
+    randomize_colors=False,
 ):
     random_state = np.random.RandomState(seed)
     walker = RollingBallWithFriction(camera_height=0.3, add_ears=top_camera)
@@ -95,6 +96,7 @@ def _memory_maze(
         enable_global_task_observables=True,  # Always add to underlying env, but not always expose in RemapObservationWrapper
         control_timestep=1.0 / control_freq,
         camera_resolution=camera_resolution,
+        target_randomize_colors=randomize_colors,
     )
 
     if top_camera:


### PR DESCRIPTION
Added environment variants
```
MemoryMaze-9x9-6CL-v0
MemoryMaze-11x11-6CL-v0
MemoryMaze-13x13-6CL-v0
```
where target colors are chosen from all 6 available colors, the same as in 15x15.

Fixes #15 